### PR TITLE
Fixed improper changelog

### DIFF
--- a/upstream/debian/docker-py/debian/changelog
+++ b/upstream/debian/docker-py/debian/changelog
@@ -1,4 +1,4 @@
-docker-py (0.6.0-1contrail1); urgency=medium
+docker-py (0.6.0-1contrail1) trusty; urgency=medium
 
   * Removed websocket for contrail
 


### PR DESCRIPTION
The current changelog of python docker is broken. This prevents the builder from packaging. 

I am not sure if this is tracked in gerrit, hence submitting a PR here