### PR TITLE
Changes to Makefile and changelog to build nova-docker with following…

### DIFF
--- a/upstream/debian/Makefile
+++ b/upstream/debian/Makefile
@@ -38,10 +38,10 @@ docker-py:$(PREP)
 nova-docker-juno: $(PREP)
 	(cd $(GIT_ROOT)/../build; if [ -d nova-docker ] ; then cd nova-docker && echo "git clean -f && git pull"; else git clone -b stable/juno git@github.com:Juniper/nova-docker.git; fi)
 	(cd $(GIT_ROOT)/../build/nova-docker/; python setup.py sdist)
-	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post155.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post155.orig.tar.gz
-	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post155.orig.tar.gz)
-	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post155/debian/; cp -Rf nova-docker/debian/juno/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post155/debian/
-	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post155; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
+	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post161.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post161.orig.tar.gz
+	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post161.orig.tar.gz)
+	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post161/debian/; cp -Rf nova-docker/debian/juno/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post161/debian/
+	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post161; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
 
 nova-docker-icehouse: $(PREP)
 	(cd $(GIT_ROOT)/../build; if [ -d nova-docker ] ; then cd nova-docker && echo "git clean -f && git pull"; else git clone -b stable/icehouse git@github.com:Juniper/nova-docker.git; fi)

--- a/upstream/debian/nova-docker/debian/juno/changelog
+++ b/upstream/debian/nova-docker/debian/juno/changelog
@@ -1,3 +1,9 @@
+nova-docker (0.0.0.post161-0contrail0) trusty; urgency=low
+
+  * Fix for the bug https://bugs.launchpad.net/nova-docker/+bug/1533037
+
+ -- Ignatious Johnson <ijohnson@juniper.net> Thu, 14 Jan 2016 00:55:40 +0000
+
 nova-docker (0.0.0.post155-0contrail0) trusty; urgency=low
    * Fix for thr bugs https://bugs.launchpad.net/juniperopenstack/+bug/1458655, 1458553
 


### PR DESCRIPTION
… fix

Use http based vrouter-port-control script to plug/unplug vif's
in the vrouter. This script ensures that port info is persisted in file.
Agent reads those files and re-adds port during restarts.

Closes-Bug: 1533037