### PR TITLE
 Changes to Makefile and changelog to build

### DIFF
--- a/upstream/debian/Makefile
+++ b/upstream/debian/Makefile
@@ -62,18 +62,18 @@ nova-docker-kilo: $(PREP)
 nova-docker-juno: $(PREP)
 	(cd $(GIT_ROOT)/../build; if [ -d nova-docker ] ; then cd nova-docker && echo "git clean -f && git pull"; else git clone -b stable/juno git@github.com:Juniper/nova-docker.git; fi)
 	(cd $(GIT_ROOT)/../build/nova-docker/; python setup.py sdist)
-	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post161.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post161.orig.tar.gz
-	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post161.orig.tar.gz)
-	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post161/debian/; cp -Rf nova-docker/debian/juno/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post161/debian/
-	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post161; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
+	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post163.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post163.orig.tar.gz
+	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post163.orig.tar.gz)
+	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post163/debian/; cp -Rf nova-docker/debian/juno/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post163/debian/
+	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post163; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
 
 nova-docker-icehouse: $(PREP)
 	(cd $(GIT_ROOT)/../build; if [ -d nova-docker ] ; then cd nova-docker && echo "git clean -f && git pull"; else git clone -b stable/icehouse git@github.com:Juniper/nova-docker.git; fi)
 	(cd $(GIT_ROOT)/../build/nova-docker/; python setup.py sdist)
-	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post124.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post124.orig.tar.gz
-	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post124.orig.tar.gz)
-	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post124/debian/; cp -Rf nova-docker/debian/icehouse/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post124/debian
-	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post124; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
+	cp $(GIT_ROOT)/../build/nova-docker/dist/nova-docker-0.0.0.post126.tar.gz $(GIT_ROOT)/../build/nova-docker_0.0.0.post126.orig.tar.gz
+	(cd $(GIT_ROOT)/../build; tar -xvzf $(GIT_ROOT)/../build/nova-docker_0.0.0.post126.orig.tar.gz)
+	mkdir -p $(GIT_ROOT)/../build/nova-docker-0.0.0.post126/debian/; cp -Rf nova-docker/debian/icehouse/* $(GIT_ROOT)/../build/nova-docker-0.0.0.post126/debian
+	(cd $(GIT_ROOT)/../build/nova-docker-0.0.0.post126; sudo pdebuild --use-pdebuild-internal --debbuildopts -tc)
 
 oslo-concurrency:$(PREP)
 	(cd $(GIT_ROOT)/../build; wget https://pypi.python.org/packages/source/o/oslo.concurrency/oslo.concurrency-1.4.1.tar.gz)

--- a/upstream/debian/nova-docker/debian/icehouse/changelog
+++ b/upstream/debian/nova-docker/debian/icehouse/changelog
@@ -1,4 +1,11 @@
+nova-docker (0.0.0.post126-0contrail0) trusty; urgency=low
+
+  * Fix for the bug https://bugs.launchpad.net/nova-docker/+bug/1533037
+
+ -- Ignatious Johnson <ijohnson@juniper.net> Fri, 13 May 2016 08:04:39 -0700
+
 nova-docker (0.0.0.post124-0contrail0) trusty; urgency=low
+
    * Fix for thr bugs https://bugs.launchpad.net/juniperopenstack/+bug/1458655, 1458553
 
  -- Ignatious Johnson <ijohnson@juniper.net> Mon, 01 Jun 2015 10:14:40 -0700

--- a/upstream/debian/nova-docker/debian/juno/changelog
+++ b/upstream/debian/nova-docker/debian/juno/changelog
@@ -1,3 +1,9 @@
+nova-docker (0.0.0.post163-0contrail0) trusty; urgency=low
+
+  * Fix to add vrouter-port-control script in the rootwrap
+
+ -- Ignatious Johnson <ijohnson@juniper.net> Fri, 13 May 2016 09:05:38 -0700
+
 nova-docker (0.0.0.post161-0contrail0) trusty; urgency=low
 
   * Fix for the bug https://bugs.launchpad.net/nova-docker/+bug/1533037


### PR DESCRIPTION
 nova-docker with following fix in icehouse version of PPA

 Use http based vrouter-port-control script to plug/unplug vif's
 in the vrouter. This script ensures that port info is persisted in file.
 Agent reads those files and re-adds port during restarts.

 Closes-Bug: 1533037