### PR TITLE
Closes Bug: #1587645. Updating ifmap-server

### DIFF
--- a/upstream/rpm/specs/ifmap-server/007_ifmap_script_change.patch
+++ b/upstream/rpm/specs/ifmap-server/007_ifmap_script_change.patch
@@ -1,0 +1,12 @@
+diff -ur --new-file ifmap-server-0.3.2/ifmap-server ifmap-server-0.3.2-new/ifmap-server
+--- ifmap-server-0.3.2/ifmap-server	2016-06-01 18:07:35.957355794 -0700
++++ ifmap-server-0.3.2-new/ifmap-server	2016-06-01 18:08:12.934067892 -0700
+@@ -1,4 +1,7 @@
+ #!/bin/sh
+ 
+ cd /usr/share/ifmap-server
+-java -cp ./lib/ -jar ./irond.jar > /var/log/contrail/ifmap-server-console.log 2>&1
++# exec to allow supervisor reap for ifmap process, enabling proper detection and life cycle
++# management of the ifmap process. Use explicit Dlog4j option to allow ifmap process to
++# be noticed by ps command and also for user contrail to run ifmap process
++exec /usr/bin/java -jar ./irond.jar -Dlog4j.configuration=file:////usr/share/ifmap-server/log4j.properties

--- a/upstream/rpm/specs/ifmap-server/ifmap-server.spec
+++ b/upstream/rpm/specs/ifmap-server/ifmap-server.spec
@@ -1,4 +1,6 @@
-%define         _relstr 2contrail
+# 3contrail seems to be present in the cache for centos65 but spec file doesnt show it. Hence
+# using 4contrail. Make sure to update tho sequence if generating new rpm for ifmap-server
+%define         _relstr 4contrail
 Name:               ifmap-server 
 Version:            0.3.2 
 Release:            %{_relstr}%{?dist}
@@ -15,6 +17,7 @@ Patch2:		    003_ifmap_split_results.patch
 Patch3:		    004_ifmap_split_config.patch
 Patch4:             005_ifmap_centos_property.patch	
 Patch5:             006_ifmap_script_add.patch
+Patch6:             007_ifmap_script_change.patch
 BuildArch: noarch
 BuildRequires: log4j 
 BuildRequires: apache-commons-codec 
@@ -44,6 +47,7 @@ ls $RPM_BUILD_DIR/irond-0.3.2-src | xargs -n 1 -I'{}' mv $RPM_BUILD_DIR/irond-0.
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
+%patch6 -p1
 	
 %build
 pushd %{_builddir}/ifmap-server-0.3.2


### PR DESCRIPTION
Closes Bug: #1587645. Updating ifmap-server with the proper command for managing ifmap-server by supervisor