### PR TITLE
Updated the Manifest file to use apache-common-codec.jar for centoslinux71

### DIFF
--- a/upstream/rpm/specs/ifmap-server/008_manifest_mf.patch
+++ b/upstream/rpm/specs/ifmap-server/008_manifest_mf.patch
@@ -1,0 +1,8 @@
+--- ifmap-server/MANIFEST.MF.orig	2016-06-08 15:07:43.399433000 -0700
++++ ifmap-server/MANIFEST.MF	2016-06-08 15:08:09.759433000 -0700
+@@ -1,4 +1,4 @@
+ Manifest-Version: 1.0
+ Main-Class: de.fhhannover.inform.iron.mapserver.Main
+-Class-Path: . /usr/share/java/log4j.jar /usr/share/java/commons-codec-1.4-redhat-1.jar /usr/share/java/jakarta-httpcore.jar
++Class-Path: . /usr/share/java/log4j.jar /usr/share/java/apache-commons-codec.jar /usr/share/java/jakarta-httpcore.jar
+ 

--- a/upstream/rpm/specs/ifmap-server/008_manifest_mf.patch
+++ b/upstream/rpm/specs/ifmap-server/008_manifest_mf.patch
@@ -1,8 +1,8 @@
---- ifmap-server/MANIFEST.MF.orig	2016-06-08 15:07:43.399433000 -0700
-+++ ifmap-server/MANIFEST.MF	2016-06-08 15:08:09.759433000 -0700
+--- ifmap-server/MANIFEST.MF.orig	2016-06-09 10:09:41.399433000 -0700
++++ ifmap-server/MANIFEST.MF	2016-06-09 10:10:10.759433000 -0700
 @@ -1,4 +1,4 @@
  Manifest-Version: 1.0
  Main-Class: de.fhhannover.inform.iron.mapserver.Main
 -Class-Path: . /usr/share/java/log4j.jar /usr/share/java/commons-codec-1.4-redhat-1.jar /usr/share/java/jakarta-httpcore.jar
-+Class-Path: . /usr/share/java/log4j.jar /usr/share/java/apache-commons-codec.jar /usr/share/java/jakarta-httpcore.jar
++Class-Path: . /usr/share/java/log4j.jar /usr/share/java/commons-codec-1.4-redhat-1.jar /usr/share/java/apache-commons-codec.jar /usr/share/java/jakarta-httpcore.jar
  

--- a/upstream/rpm/specs/ifmap-server/ifmap-server.spec
+++ b/upstream/rpm/specs/ifmap-server/ifmap-server.spec
@@ -18,6 +18,7 @@ Patch3:		    004_ifmap_split_config.patch
 Patch4:             005_ifmap_centos_property.patch	
 Patch5:             006_ifmap_script_add.patch
 Patch6:             007_ifmap_script_change.patch
+Patch7:             008_manifest_mf.patch
 BuildArch: noarch
 BuildRequires: log4j 
 BuildRequires: apache-commons-codec 
@@ -48,6 +49,7 @@ ls $RPM_BUILD_DIR/irond-0.3.2-src | xargs -n 1 -I'{}' mv $RPM_BUILD_DIR/irond-0.
 %patch4 -p1
 %patch5 -p1
 %patch6 -p1
+%patch7 -p1
 	
 %build
 pushd %{_builddir}/ifmap-server-0.3.2


### PR DESCRIPTION
Closes-Bug: #1587645. Updated the Manifest file to use apache-common-codec.jar for centoslinux71 and commons-codec-1.4-redhat-1.jar for centos6