### PR TITLE
Build RPM package for python bitstring module.

### DIFF
--- a/upstream/rpm/Makefile
+++ b/upstream/rpm/Makefile
@@ -125,6 +125,15 @@ python-bitarray: $(PREP)
 	mock -r $(MOCK_CONFIG_LOCATION) $(BUILD_BASE)/BUILD/python-bitarray*.src.rpm --resultdir $(BUILD_BASE)/BUILD
 	rm -f specs/python-bitarray/bitarray*.tar.gz
 
+python-bitstring: $(PREP)
+	@echo "About to make python-bitstring"
+	#Fetch the source
+	spectool -g -R specs/python-bitstring/python-bitstring.spec -C specs/python-bitstring/
+	#mock instructions
+	mock -r $(MOCK_CONFIG_LOCATION) --buildsrpm --sources specs/python-bitstring/ --spec specs/python-bitstring/python-bitstring.spec --resultdir=$(BUILD_BASE)/BUILD
+	mock -r $(MOCK_CONFIG_LOCATION) $(BUILD_BASE)/BUILD/python-bitstring*.src.rpm --resultdir $(BUILD_BASE)/BUILD
+	rm -f specs/python-bitstring/bitstring*.zip
+
 python-thrift: $(PREP)
 	@echo "About to make python-thrift"
 	#Fetch the source
@@ -283,4 +292,5 @@ all:$(PREP) \
 	python-bitarray python-thrift redis-py \
 	xmltodict libvirt docker-py kafka librdkafka \
         kafka-python python-kazoo-1.3.1 python-ncclient-0.3.2 \
-	python-cassandra librdkafka-0.9.0 zookeeper-3.4.8 python-sseclient
+	python-cassandra librdkafka-0.9.0 zookeeper-3.4.8 python-sseclient \
+	python-bitstring

--- a/upstream/rpm/specs/python-bitstring/python-bitstring.spec
+++ b/upstream/rpm/specs/python-bitstring/python-bitstring.spec
@@ -1,0 +1,108 @@
+%define name bitstring
+%define version 3.1.5
+%define unmangled_version 3.1.5
+%define release 1
+%define _relstr 0contrail0
+Summary: Simple construction, analysis and modification of binary data.
+Name: python-%{name}
+Version: %{version}
+Release: %{release}.%{_relstr}
+Source0: https://pypi.python.org/packages/f3/e5/dfe4c49c93d174a5fd807ed307d3a3f38c6b3e140972945f81a5f5578ca7/bitstring-3.1.5.zip
+License: MIT
+Group: Development/Libraries
+Prefix: %{_prefix}
+Vendor: Scott Griffiths <dr.scottgriffiths@gmail.com>
+Url: https://github.com/scott-griffiths/bitstring
+BuildRequires: python-devel
+
+%description
+==================
+Bitstring Module
+==================
+
+bitstring is a pure Python module designed to help make the creation and analysis of binary data as simple and natural as possible.
+
+Bitstrings can be constructed from integers (big and little endian), hex, octal, binary, strings or files. They can be sliced, joined, reversed, inserted into, overwritten, etc. with simple functions or slice notation. They can also be read from, searched and replaced, and navigated in, similar to a file or stream.
+
+bitstring is open source software, and has been released under the MIT licence.
+
+This module works in both Python 2.7 and Python 3.
+
+Documentation
+
+The manual for the bitstring module is available here <http://packages.python.org/bitstring>. It contains a walk-through of all the features and a complete reference section.
+
+It is also available as a PDF as part of the source download.
+
+Installation
+
+If you have downloaded and unzipped the package then you need to run the setup.py script with the 'install' argument:
+
+python setup.py install
+You may need to run this with root privileges on Unix-like systems.
+
+If you haven't yet downloaded the package then you can just try:
+
+easy_install bitstring
+or
+
+pip install bitstring
+Simple Examples
+
+Creation:
+
+>>> a = BitArray(bin='00101')
+>>> b = Bits(a_file_object)
+>>> c = BitArray('0xff, 0b101, 0o65, uint:6=22')
+>>> d = pack('intle:16, hex=a, 0b1', 100, a='0x34f')
+>>> e = pack('<16h', *range(16))
+Different interpretations, slicing and concatenation:
+
+>>> a = BitArray('0x1af')
+>>> a.hex, a.bin, a.uint
+('1af', '000110101111', 431)
+>>> a[10:3:-1].bin
+'1110101'
+>>> 3*a + '0b100'
+BitArray('0o0657056705674')
+Reading data sequentially:
+
+>>> b = BitStream('0x160120f')
+>>> b.read(12).hex
+'160'
+>>> b.pos = 0
+>>> b.read('uint:12')
+352
+>>> b.readlist('uint:12, bin:3')
+[288, '111']
+Searching, inserting and deleting:
+
+>>> c = BitArray('0b00010010010010001111')   # c.hex == '0x1248f'
+>>> c.find('0x48')
+(8,)
+>>> c.replace('0b001', '0xabc')
+>>> c.insert('0b0000')
+>>> del c[12:16]
+Unit Tests
+
+The 400+ unit tests should all pass for Python 2.6 and later.
+
+The bitstring module has been released as open source under the MIT License. Copyright (c) 2016 Scott Griffiths
+
+For more information see the project's homepage on GitHub: <https://github.com/scott-griffiths/bitstring>
+
+%prep
+
+%setup -n %{name}-%{unmangled_version}
+
+%build
+env CFLAGS="$RPM_OPT_FLAGS" python setup.py build
+
+%install
+python setup.py install -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -f INSTALLED_FILES
+%defattr(-,root,root)


### PR DESCRIPTION
These changes are to include and build python bitstring module as a
third party package. Bitstring module is needed by contrail kube-manager
component which will be made available on both debian and redhat containers.
Debian package is already made available in contrail cache.
But RPM package is not readily available from authorized websites.
So these changes are to build RPM out of python-bitstring module sources.

Partial-Bug: #1639062