### PR TITLE
[ifmap-server]: Do not throw exception when some entries are already …

### DIFF
--- a/upstream/rpm/specs/ifmap-server/011_ifmap_bug_1688227.patch
+++ b/upstream/rpm/specs/ifmap-server/011_ifmap_bug_1688227.patch
@@ -1,0 +1,66 @@
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
+index 9f13ed2..9e25015 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
+@@ -128,9 +128,9 @@ abstract class GraphElementImpl implements GraphElement {
+ 	@Override
+ 	public void addMetadataHolder(MetadataHolder m) {
+ 		NullCheck.check(m, "MetadataHolder is null");
+-		if (mMetadataHolder.contains(m))
+-			throw new SystemErrorException("MetadataHolder " + m + " already on "
+-					+ this);
++		if (mMetadataHolder.contains(m)) {
++                        return;
++                }
+ 		
+ 		mMetadataHolder.add(m);
+ 	}
+@@ -140,10 +140,9 @@ abstract class GraphElementImpl implements GraphElement {
+ 		NullCheck.check(m, "MetadataHolder is null");
+ 		int idx = mMetadataHolder.indexOf(m);
+ 		
+-		if (idx < 0)
+-			throw new SystemErrorException("MetadataHolder " + m + " not on " + this);
+-		
+-		mMetadataHolder.remove(idx);
++		if (idx >= 0) {
++		        mMetadataHolder.remove(idx);
++                }
+ 	}
+ 
+ 	@Override
+@@ -165,16 +164,11 @@ abstract class GraphElementImpl implements GraphElement {
+ 	public void addSubscriptionEntry(SubscriptionEntry entry) {
+ 		NullCheck.check(entry, "entry is null");
+ 		NullCheck.check(entry.getSubscription(), "sub is null");
+-		if (mSubscriptionEntries.put(entry.getSubscription(), entry) != null)
+-			throw new SystemErrorException("entry " + entry
+-					+ " already on " + this);
+ 	}
+ 
+ 	@Override
+ 	public void removeSubscriptionEntry(Subscription sub) {
+ 		NullCheck.check(sub, "Subscription is null");
+-		if (mSubscriptionEntries.remove(sub) == null)
+-			throw new SystemErrorException("entry for " + sub + " not on "  + this);
+ 	}
+ 
+ 	@Override
+@@ -196,17 +190,11 @@ abstract class GraphElementImpl implements GraphElement {
+ 	public void addRemovedSubscriptionEntry(SubscriptionEntry entry) {
+ 		NullCheck.check(entry, "entry is null");
+ 		NullCheck.check(entry.getSubscription(), "sub is null");
+-		if (mRemovedSubscriptionEntries.put(entry.getSubscription(), entry) != null)
+-			throw new SystemErrorException("entry " + entry
+-					+ " already removed for  " + this);
+ 	 }
+ 	
+ 	@Override
+ 	public void removeRemovedSubscriptionEntry(Subscription sub) {
+ 		NullCheck.check(sub, "Subscription is null");
+-		if (mRemovedSubscriptionEntries.remove(sub) == null)
+-			throw new SystemErrorException("entry for " + sub + " not removed for " 
+-					+ this);
+ 	}
+ 	
+ 	@Override

--- a/upstream/rpm/specs/ifmap-server/ifmap-server.spec
+++ b/upstream/rpm/specs/ifmap-server/ifmap-server.spec
@@ -1,6 +1,6 @@
 # 3contrail seems to be present in the cache for centos65 but spec file doesnt show it. Hence
 # using 4contrail. Make sure to update tho sequence if generating new rpm for ifmap-server
-%define         _relstr 5contrail
+%define         _relstr 6contrail
 Name:               ifmap-server 
 Version:            0.3.2 
 Release:            %{_relstr}%{?dist}
@@ -22,6 +22,7 @@ Patch7:             007_ifmap_leak_fixes.patch
 Patch8:             008_ifmap_script_add.patch
 Patch9:             009_ifmap_script_change.patch
 Patch10:            010_manifest_mf.patch
+Patch11:            011_ifmap_bug_1688227.patch
 BuildArch: noarch
 BuildRequires: log4j 
 BuildRequires: apache-commons-codec 

--- a/upstream/rpm/utils/epel-7-x86_64-contrail.cfg
+++ b/upstream/rpm/utils/epel-7-x86_64-contrail.cfg
@@ -2,7 +2,7 @@ config_opts['root'] = 'epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 #config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
-config_opts['chroot_setup_cmd'] = 'install @buildsys-build scl-utils-build python27-build'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build scl-utils-build python27-build java-1.7.0-openjdk java-1.7.0-openjdk-devel java-1.7.0-openjdk-headless'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 # beware RHEL use 7Server or 7Client
 config_opts['releasever'] = '7'


### PR DESCRIPTION
…removed

The fix avoids raising exception when a non-existed link is being removed from the graph data structure. The reason is the link is removed already and no longer presents in the graph, hence we could ignore safely if there is no link in "Removal" case. The exception causing a problem, it stops the execution of propagating API data changes to control node.

Closes-Bug: #1688227