### PR TITLE
[ifmap-server]: Fixes for ebay/workday ifmap server issue

### DIFF
--- a/upstream/rpm/specs/ifmap-server/011_ifmap_bug_1688227.patch
+++ b/upstream/rpm/specs/ifmap-server/011_ifmap_bug_1688227.patch
@@ -1,5 +1,26 @@
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
+index edb6312..e3b7ea1 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/SubscriptionService.java
+@@ -253,9 +253,13 @@ public class SubscriptionService {
+ 		
+ 		for (GraphElement ge : visitedGraphElement) {
+ 			initSres.addGraphElement(ge);
+-			
+-			for (MetadataHolder mh : ge.getSubscriptionEntry(sub).getMetadataHolder())
+-				initSres.addMetadata(ge, mh.getMetadata());
++		        SubscriptionEntry se = ge.getSubscriptionEntry(sub);
++                        if (se != null && se.getMetadataHolder() != null) {
++			        for (MetadataHolder mh : se.getMetadataHolder())
++				    initSres.addMetadata(ge, mh.getMetadata());
++                        } else {
++                               sLogger.debug(sName + "Subscription Entry/Metadata Holder is NULL for (ge, sub): " + ge + "/" + sub); 
++                        }
+ 		}
+ 		
+ 		// Sanitize check: An initial search never leads to new Starters.
 diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
-index 9f13ed2..9e25015 100644
+index 9f13ed2..f936a15 100644
 --- a/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
 +++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/graph/GraphElementImpl.java
 @@ -128,9 +128,9 @@ abstract class GraphElementImpl implements GraphElement {
@@ -29,13 +50,14 @@ index 9f13ed2..9e25015 100644
  	}
  
  	@Override
-@@ -165,16 +164,11 @@ abstract class GraphElementImpl implements GraphElement {
+@@ -165,16 +164,13 @@ abstract class GraphElementImpl implements GraphElement {
  	public void addSubscriptionEntry(SubscriptionEntry entry) {
  		NullCheck.check(entry, "entry is null");
  		NullCheck.check(entry.getSubscription(), "sub is null");
 -		if (mSubscriptionEntries.put(entry.getSubscription(), entry) != null)
 -			throw new SystemErrorException("entry " + entry
 -					+ " already on " + this);
++                mSubscriptionEntries.put(entry.getSubscription(), entry);
  	}
  
  	@Override
@@ -43,16 +65,18 @@ index 9f13ed2..9e25015 100644
  		NullCheck.check(sub, "Subscription is null");
 -		if (mSubscriptionEntries.remove(sub) == null)
 -			throw new SystemErrorException("entry for " + sub + " not on "  + this);
++                mSubscriptionEntries.remove(sub);
  	}
  
  	@Override
-@@ -196,17 +190,11 @@ abstract class GraphElementImpl implements GraphElement {
+@@ -196,17 +192,13 @@ abstract class GraphElementImpl implements GraphElement {
  	public void addRemovedSubscriptionEntry(SubscriptionEntry entry) {
  		NullCheck.check(entry, "entry is null");
  		NullCheck.check(entry.getSubscription(), "sub is null");
 -		if (mRemovedSubscriptionEntries.put(entry.getSubscription(), entry) != null)
 -			throw new SystemErrorException("entry " + entry
 -					+ " already removed for  " + this);
++                mRemovedSubscriptionEntries.put(entry.getSubscription(), entry);
  	 }
  	
  	@Override
@@ -61,6 +85,23 @@ index 9f13ed2..9e25015 100644
 -		if (mRemovedSubscriptionEntries.remove(sub) == null)
 -			throw new SystemErrorException("entry for " + sub + " not removed for " 
 -					+ this);
++                mRemovedSubscriptionEntries.remove(sub);
  	}
  	
  	@Override
+diff --git a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionImpl.java b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionImpl.java
+index 98d5a04..ba69ec7 100644
+--- a/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionImpl.java
++++ b/src/de/fhhannover/inform/iron/mapserver/datamodel/search/SubscriptionImpl.java
+@@ -131,10 +131,7 @@ class SubscriptionImpl implements Subscription {
+ 	@Override
+ 	public void addGraphElement(GraphElement ge) {
+ 		NullCheck.check(ge, "mc is null");
+-		if (mGraphElements.put(ge, ge) != null)
+-			throw new SystemErrorException("Container " + ge + " was already on"
+-					+ " on " + this);
+-		
++                mGraphElements.put(ge, ge);
+ 	}
+ 
+ 	/* (non-Javadoc)


### PR DESCRIPTION
The fix avoids raising exception when a non-existed link is being
removed from the graph data structure. The reason is the link is
removed already and no longer presents in the graph, hence we could ignore
safely if there is no link in "Removal" case.
The exception causing a problem, it stops the execution of propagating
API data changes to control node.
This is additional fix added to the previous fix.
https://github.com/Juniper/contrail-third-party-packages/pull/72

Closes-Bug: #1688227